### PR TITLE
Update the CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,112 @@
 version: 2.1
+
+# References for reuse across different jobs
+references:
+
+  # Shared container config for all jobs
+  container_config: &container_config
+    docker:
+      - image: circleci/ruby:2.4.5-node
+
+  # Shared cache configuration (restoring)
+  cache_restore_config: &cache_restore_config
+    restore_cache:
+      keys:
+        - dependency-cache-v4-{{ arch }}-{{ .Branch }}-gem{{ checksum "Gemfile.lock" }}-npm{{ checksum "package-lock.json" }}
+        - dependency-cache-v4-{{ arch }}-{{ .Branch }}-gem{{ checksum "Gemfile.lock" }}
+        - dependency-cache-v4-{{ arch }}-{{ .Branch }}
+        - dependency-cache-v4
+
+  # Shared cache configuration (saving)
+  cache_save_config: &cache_save_config
+    save_cache:
+      key: dependency-cache-v4-{{ arch }}-{{ .Branch }}-gem{{ checksum "Gemfile.lock" }}-npm{{ checksum "package-lock.json" }}
+      paths:
+        - node_modules
+        - vendor/bundle
+
+  # Shared installation command
+  install_config: &install_config
+    run:
+      name: Install all dependencies
+      command: make install
+
+# Actual CI jobs
 jobs:
+
+  # Test job, which runs validates data
   test:
-    docker:
-      - image: circleci/ruby:2.4.5-node
+    <<: *container_config
     steps:
       - checkout
-      - run: make install
-      - run: make build
-      - run: make test
+      - *cache_restore_config
+      - *install_config
+      - *cache_save_config
+      - run:
+          name: Run the tests
+          command: make test
+
+  # Publish the Jekyll website
   publish-website:
-    docker:
-      - image: circleci/ruby:2.4.5-node
+    <<: *container_config
     steps:
       - checkout
-      - run: make install
-      - run: make build
-      - run: git config --global user.email "origami.support@ft.com"
-      - run: git config --global user.name "origamiserviceuser [bot]";
-      - run: make publish-website
+      - *cache_restore_config
+      - *install_config
+      - *cache_save_config
+      - run:
+          name: Configure Git
+          command: |
+            git config --global user.email "origami.support@ft.com"
+            git config --global user.name "origamiserviceuser [bot]"
+      - run:
+          name: Build and publish the website
+          command: make publish-website
+
+  # Deploy competency data to a different format after a release
+  deploy:
+    <<: *container_config
+    steps:
+      - checkout
+      - *cache_restore_config
+      - *install_config
+      - *cache_save_config
+      - run:
+          name: TODO
+          command: echo "TODO add deploys, e.g. Google Sheets"
+
+# Workflows
 workflows:
   version: 2
-  test-and-publish:
+  test-publish-deploy:
     jobs:
-      - test
-      - publish-website:
+
+      # Run tests against any branch that is not the
+      # GitHub Pages branch
+      - test:
           filters:
-            tags:
-              only: /^v.*/
+            branches:
+              ignore: gh-pages
+
+      # Publish the Jekyll website only on commits to
+      # the master branch, or a tag which is a valid
+      # semantic version
+      - publish-website:
+          requires:
+            - test
+          filters:
             branches:
               only: master
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+([-+].+)?/
+
+      # Deploy competency data to a different format
+      # only on a tag which is a valid semantic version
+      - deploy:
+          requires:
+            - publish-website
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+([-+].+)?/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.bundle
 dist
 node_modules
+vendor
 
 # This ignored here rather than inside the
 # site directory so that the API pages

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ TASK_DONE = echo "✓ $@ done"
 all: install build test
 install: install-ruby-gems install-node-modules
 build: build-competencies-json build-website
-test: build validate-competencies-json
+test: validate-competencies-json
 
 
 # Installation tasks
@@ -50,7 +50,12 @@ endif
 
 # Install ruby gems
 install-ruby-gems: install-bundler
-	@bundle install
+ifdef CI
+	@bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
+	@bundle package
+else
+	@bundle check || bundle install
+endif
 	@$(TASK_DONE)
 
 # Install node modules
@@ -77,21 +82,21 @@ endif
 
 # Build the competencies website
 build-website: build-website-api
-	@jekyll build $(JEKYLL_OPTIONS)
+	@bundle exec jekyll build $(JEKYLL_OPTIONS)
 	@$(TASK_DONE)
 
 # Build and serve the website for local development.
 # Simpler naming is for ease of local development,
 # this is not used in the build pipeline
 website:
-	@jekyll serve --watch --livereload $(JEKYLL_OPTIONS)
+	@bundle exec jekyll serve --watch --livereload $(JEKYLL_OPTIONS)
 
 
 # Test tasks
 # ----------
 
 # Validate the competencies JSON
-validate-competencies-json:
+validate-competencies-json: build-competencies-json
 	@./script/validate-competencies-json.js
 	@$(TASK_DONE)
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ make install
 You may have noticed that the competencies data is stored as YAML in this repo. This is useful for editing, but JSON is far easier to process programmatically. Once you've [cloned this repository](https://help.github.com/articles/cloning-a-repository/) locally, you will be able to build the competencies JSON with this command:
 
 ```sh
-make build
+make build-competencies-json
 ```
 
 This will create a `dist` folder in the repo, which will contain a `competencies.json` file. It's important to note that this generated file cannot be used to edit competencies, and will be overridden entirely every time `make build` is run.
@@ -84,7 +84,7 @@ make website
 The local website will not have any API endpoints unless you generate them manually. On CI and in production this can be automated. To build an API endpoints, run the following:
 
 ```sh
-CIRCLE_TAG=v1.0.0 make build
+CIRCLE_TAG=v1.0.0 make build-website-api
 ```
 
 This will generate the API endpoint `/api/v1/competencies.json`. The `v1` in the URL corresponds to the Circle tag that you specify, so if you wanted to create a `v2` endpoint you should specify `CIRCLE_TAG=v2.0.0`.


### PR DESCRIPTION
This now includes a deploy job which is run on a release, but only after
the website has been published. This allows deploy jobs to trigger
something that _pulls_ from the new live JSON on the website.

I've also overhauled the CI config a bit, adding in caching because this
was already quite slow. Speed of building gets more and more important
as we add multiple deploy targets. This lead to some minor changes to
the Makefile as well, to optimise the build process.

This work is required before any of us can actually start writing deploy
scripts.