### PR TITLE
Make the UUID regex more lenient

### DIFF
--- a/test/schema/competencies.json
+++ b/test/schema/competencies.json
@@ -18,7 +18,7 @@
 					"description": "A unique identifier for the competency",
 					"type": "string",
 					"minLength": 2,
-					"pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4{1}[a-fA-F0-9]{3}-[89abAB]{1}[a-fA-F0-9]{3}-[a-fA-F0-9]{12}"
+					"pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5]{1}[a-fA-F0-9]{3}-[89abAB]{1}[a-fA-F0-9]{3}-[a-fA-F0-9]{12}"
 				},
 				"summary": {
 					"title": "Summary",


### PR DESCRIPTION
PR #30's build failed initially because a v1 UUID was used rather than
v4. There's no issue with using older or newer UUIDs, so I've updated
the validation to allow for versions 1–5.

This probably also highlights that we should provide some guidance in
the documentation on where to get your IDs. Or possibly we should add a
command-line tool to help generate them.