### PR TITLE
Add placeholder text to the website

### DIFF
--- a/site/pages/home.html
+++ b/site/pages/home.html
@@ -1,6 +1,6 @@
 ---
 title: Engineering Progression
-description: TODO
+description: Careers and progression for engineers in the CTO organisation at the FT.
 permalink: /
 layout: o-layout-landing
 ---
@@ -9,7 +9,7 @@ layout: o-layout-landing
 
 	<h1>{{page.title}}</h1>
 	<p>
-		TODO this is a description.
+		Careers and progression for engineers in the CTO organisation at the FT.
 	</p>
 
 </div>
@@ -19,50 +19,49 @@ layout: o-layout-landing
 	<div class="o-layout__overview">
 
 		<div class="o-layout-item">
-			<h2>Example</h2>
+			<h2>Overview</h2>
 			<p>
-				TODO this could be some content. It doesn't have to be in this exact format.
+				This site and the accompanying repository is the single source of truth for the
+				competencies and level definitions for Engineering roles in the CTO organisation at
+				the FT.
+			</p>
+			<p>
+				You can find more information on the <a href="{{site.github.repository_url}}#readme" class="o-typography-link--external">GitHub repository</a>
+			</p>
+		</div>
+
+		<div class="o-layout-item">
+			<h2>Competencies</h2>
+			<p>
+				Engineering competencies are used to help identify when an engineer is ready for
+				promotion:
 			</p>
 			<ul>
-				<li><a href="/">Example link</a></li>
-				<li><a href="/">Example link</a></li>
-				<li><a href="/">Example link</a></li>
+				<li><a href="https://docs.google.com/spreadsheets/d/1V0LIbCQtJsi2iowfJnRTDr4Na4LhNAlJ_UHl9dDQs00/edit" class="o-typography-link--external">Track progress with your manager or report via Google Sheets</a></li>
+				<li><a href="{{site.github.repository_url}}/blob/master/data/competencies.yml" class="o-typography-link--external">Read as YAML in the repository</a></li>
 			</ul>
 		</div>
 
 		<div class="o-layout-item">
-			<h2>Example</h2>
+			<h2>Contributing</h2>
 			<p>
-				TODO this could be some content. It doesn't have to be in this exact format.
+				Anybody working for the Financial Times is welcome to suggest changes via a GitHub
+				issue or pull request.
 			</p>
 			<ul>
-				<li><a href="/">Example link</a></li>
-				<li><a href="/">Example link</a></li>
-				<li><a href="/">Example link</a></li>
+				<li><a href="{{site.github.repository_url}}/blob/master/CONTRIBUTING.md#contributing" class="o-typography-link--external">Read the contributing guide</a></li>
+				<li><a href="{{site.github.repository_url}}/issues/new" class="o-typography-link--external">Open an issue on GitHub</a></li>
 			</ul>
 		</div>
 
 		<div class="o-layout-item">
-			<h2>Example</h2>
+			<h2>Contact</h2>
 			<p>
-				TODO this could be some content. It doesn't have to be in this exact format.
+				If you'd like to contact the Engineering Progression Working Group for any reason, you can do so here:
 			</p>
 			<ul>
-				<li><a href="/">Example link</a></li>
-				<li><a href="/">Example link</a></li>
-				<li><a href="/">Example link</a></li>
-			</ul>
-		</div>
-
-		<div class="o-layout-item">
-			<h2>Example</h2>
-			<p>
-				TODO this could be some content. It doesn't have to be in this exact format.
-			</p>
-			<ul>
-				<li><a href="/">Example link</a></li>
-				<li><a href="/">Example link</a></li>
-				<li><a href="/">Example link</a></li>
+				<li><a href="mailto:{{site.data.contact.email}}">{{site.data.contact.email}}</a></li>
+				<li><a href="https://financialtimes.slack.com/messages/{{site.data.contact.slack}}" class="o-typography-link--external">#{{site.data.contact.slack}}</a></li>
 			</ul>
 		</div>
 


### PR DESCRIPTION
For launch, the website should probably contain more than just "example"
over and over again. I've written something that is imperfect, based on
the rest of the documentation.

The page mostly just links out to different areas of the repo, but now
it at least it can act as a landing page for the whole project.