### PR TITLE
Fix the website build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,7 @@ endif
 # built competency data from the main repo into
 # the Jekyll data folder
 build-website-data: build-competencies-json
-ifdef CIRCLE_TAG
 	@./script/build-website-data.js
-endif
 	@$(TASK_DONE)
 
 # Build the competencies website
@@ -138,8 +136,8 @@ publish-website: build-website
 	@git checkout gh-pages
 	@git pull origin gh-pages
 	@git rm -r .
-	@git reset HEAD .circleci .gitignore ./api ./_data/competencies.json ./_data/competencies-version.json ./_data/level.json CNAME
-	@git checkout .circleci .gitignore ./api ./_data/competencies.json ./_data/competencies-version.json ./_data/level.json CNAME
+	@git reset HEAD .circleci .gitignore ./api CNAME
+	@git checkout .circleci .gitignore ./api CNAME
 	@cp -r dist/site/* .
 ifdef CIRCLE_TAG
 	@if [ "$$(git status --porcelain)" != "" ]; then \

--- a/script/build-website-data.js
+++ b/script/build-website-data.js
@@ -12,20 +12,13 @@ process.on('unhandledRejection', error => {
 });
 
 buildWebsiteData({
-	tag: process.env.CIRCLE_TAG,
 	dataPath: path.resolve(__dirname, '..', 'site', '_data'),
 	competencies
 });
 
-async function buildWebsiteData({tag, dataPath, competencies}) {
-	if (!tag || !semver.valid(tag)) {
-		process.exitCode = 1;
-		return console.error('Error: CIRCLE_TAG environment variable must be set to a valid semver version');
-	} else {
-		await createCompetenciesData(competencies, dataPath);
-		await createLevelsData(levels, dataPath);
-		await createCompetenciesVersionData(tag, dataPath);
-	}
+async function buildWebsiteData({dataPath, competencies}) {
+	await createCompetenciesData(competencies, dataPath);
+	await createLevelsData(levels, dataPath);
 }
 
 function createCompetenciesData(competencies, dataPath) {
@@ -40,9 +33,4 @@ function createLevelsData(levels, dataPath) {
 	return outputJSON(levelsPath, levels, {
 		spaces: '\t'
 	});
-}
-
-function createCompetenciesVersionData(version, dataPath) {
-	const competenciesVersionPath = path.join(dataPath, 'competencies-version.json');
-	return outputJSON(competenciesVersionPath, version);
 }

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -3,4 +3,3 @@ _site
 .sass-cache
 _data/competencies.json
 _data/levels.json
-_data/competencies-version.json

--- a/site/pages/competencies.html
+++ b/site/pages/competencies.html
@@ -10,11 +10,6 @@ layout: o-layout-docs
 
 <p><strong>[this page demonstrates how to render competencies data in the site]</strong></p>
 
-
-<h2>Version</h2>
-
-<p>The competencies version is <strong>{{site.data.competencies-version}}</strong></p>
-
 {% for level in site.data.levels %}
 
 	<h2>{{level.name}}</h2>


### PR DESCRIPTION
We can't only build competencies data on a version change, due to the
more complicated way the website is built. Because the generated site is
committed to the gh-pages branch rather than the actual Jekyll site, we
can't only generate the `_data` folder on a valid tag. This means that
the competencies on the website directly reflect the YAML rather than
the last _version_ of the competencies. I may be able to address this
later, but for now the build is broken.