### PR TITLE
Add charts to the spreadsheet

### DIFF
--- a/docs/repository.md
+++ b/docs/repository.md
@@ -35,6 +35,13 @@ We create releases through the GitHub interface, they follow these rules:
   - The description must contain a list of all the commits that have made it onto the `master` branch since the last release
   - If the tagname includes a prerelease, then the release must have the prerelease checkbox checked
 
+There are some things that need to happen immediately after a release, which unfortunately cannot be automated. The release process is as follows:
+
+  1. **Create release:**<br/>Create a release on the GitHub repo, following the rules outlined above
+  2. **Wait for CI:**<br/>Wait for the CircleCI build to pass, and for all the integrations to deploy
+  3. **Update chart colours:**<br/>Update the chart colours in the newly-deployed [Google spreadsheet](https://docs.google.com/spreadsheets/d/1V0LIbCQtJsi2iowfJnRTDr4Na4LhNAlJ_UHl9dDQs00/edit). There are four bar charts, one for each level, each on a separate sheet. The bar chart colours cannot be updated through the API and so this must be done manually after the deploy. The series "Bar 1" must be set to the colour `#3d9199`. The series "Bar 2" must have no colour (select "None").
+
+
 ### Major Versions
 
 A major version bump must happen when a change to the engineering competencies requires something **new** of an engineer to meet the level above their current one.


### PR DESCRIPTION
This adds a bar chart to each level spreadsheet, which adds quite a lot
of extra code to the Google Sheets deploy script. I've tried to abstract
where I can, but we have to create four extra hidden calculation sheets
(to store the aggregated chart data) as well as a chart for each level.