### PR TITLE
Remove the hard-coded links from link headings

### DIFF
--- a/site/pages/competencies.html
+++ b/site/pages/competencies.html
@@ -6,15 +6,12 @@ layout: o-layout-docs
 ---
 
 
-<h1 class="o-layout__linked-heading">{{page.title}}</h1>
+<h1>{{page.title}}</h1>
 
 {% for level in site.data.levels %}
 
-	<h2 class="o-layout__linked-heading" id="#{{level.id}}">
-		<a href="#{{level.id}}" class="o-layout__linked-heading__link">
-			<span class="o-layout__linked-heading__content">{{level.name}}</span>
-			<span class="o-layout__linked-heading__label">#</span>
-		</a>
+	<h2 class="o-layout__linked-heading" id="{{level.id}}">
+		{{level.name}}
 	</h2>
 	<p>{{level.summary}}</p>
 		<table class="o-table  o-table--row-stripes" data-o-component="o-table">


### PR DESCRIPTION
o-layout was generating another link and wrapping it around the
hard-coded ones. I think it's OK to remove the hard-coded ones for now,
though it means that the heading links are only present if JavaScript
loads.

It is possible to disable the auto-linking in o-layout manually, but:

1. It's not documented (we're doing this now)
2. It doesn't have a check in place to make sure that the heading
   doesn't already contain a link. I'm going to suggest this

Once we've done these things then I may add hard-coded links back in.