### PR TITLE
Relax wording on "contributes to personal development"

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -729,7 +729,7 @@
   domain: null
 
 - id: 7e613602-fda1-43dc-94ca-83e17b24f42c
-  summary: Contributes to the personal development of more junior people in their team
+  summary: Contributes to the personal development of more junior people
   examples:
     - Pairs with more junior team members
     - Mentors people


### PR DESCRIPTION
Fixes issue #103 - The way this was worded felt like it's wasnt possible
for anyone mid-level in Origami to meet. I have removed "their team", as
mentoring often doesn't happen within the team.