### PR TITLE
Relax the requirement that all competencies be met

### DIFF
--- a/site/pages/competencies/how-to-use.md
+++ b/site/pages/competencies/how-to-use.md
@@ -26,7 +26,7 @@ So, for example, a Junior Engineer should be working towards the competencies at
 
 Each competency has a summary which is designed to prompt a yes/no response. For each competency, an engineer should feel able to answer either _"yes, I'm meeting this competency"_, or _"no, I'm not meeting this competency yet"_.
 
-In order to be promoted, an engineer must specify which competencies they are meeting for a level. We don't expect that an engineer will _meet_ all of the competencies, but the promotions board will consider all of the competencies when making a decision. Domain-specific competencies that don't apply to an engineer's role or specialism will not be considered as part of a promotions case.
+In order to be promoted, an engineer must specify which competencies they are meeting for a level. We don't expect that _every_ engineer will meet _all_ of the competencies, but the promotions board will consider all of the competencies when making a decision. Domain-specific competencies that don't apply to an engineer's role or specialism will not be considered as part of a promotions case.
 
 Engineers are expected to provide evidence that they are are meeting a competency when it comes to writing a promotions case. We expect a sentence or two, and an engineer's line manager should be ready to provide further detail if necessary. A copy of the <a href="https://docs.google.com/spreadsheets/d/1V0LIbCQtJsi2iowfJnRTDr4Na4LhNAlJ_UHl9dDQs00/edit" class="o-typography-link--external">Engineering Progression Tracker (Google Sheet)</a> is useful for keeping track of progress. Evidence must also be provided for competencies that are not being met to explain why they have not or cannot be met.
 

--- a/site/pages/competencies/how-to-use.md
+++ b/site/pages/competencies/how-to-use.md
@@ -26,7 +26,29 @@ So, for example, a Junior Engineer should be working towards the competencies at
 
 Each competency has a summary which is designed to prompt a yes/no response. For each competency, an engineer should feel able to answer either _"yes, I'm meeting this competency"_, or _"no, I'm not meeting this competency yet"_.
 
-Engineers are expected to meet all of the competencies for a level in order to be promoted, _except_ for domain-specific competencies that don't apply to their role or specialism.
+In order to be promoted, an engineer must specify which competencies they are meeting for a level. We don't expect that an engineer will _meet_ all of the competencies, but the promotions board will consider all of the competencies when making a decision. Domain-specific competencies that don't apply to an engineer's role or specialism will not be considered as part of a promotions case.
+
+Engineers are expected to provide evidence that they are are meeting a competency when it comes to writing a promotions case. We expect a sentence or two, and an engineer's line manager should be ready to provide further detail if necessary. A copy of the <a href="https://docs.google.com/spreadsheets/d/1V0LIbCQtJsi2iowfJnRTDr4Na4LhNAlJ_UHl9dDQs00/edit" class="o-typography-link--external">Engineering Progression Tracker (Google Sheet)</a> is useful for keeping track of progress. Evidence must also be provided for competencies that are not being met to explain why they have not or cannot be met.
+
+An example of how you might provide evidence for met and unmet competencies:
+
+<table class="o-table o-layout__main__single-span" data-o-component="o-table">
+	<tr>
+		<th>Competency</th>
+		<th>Done?</th>
+		<th>Evidence</th>
+	</tr>
+	<tr>
+		<td>Contributes to the personal development of more junior people</td>
+		<td>Yes</td>
+		<td>Has been mentoring a junior member of staff for six months. Ran a department-wide Git workshop</td>
+	</tr>
+	<tr>
+		<td>Leads hiring process for new Engineers</td>
+		<td>No</td>
+		<td>The team has not had to hire new engineers in the last year, and so this competency cannot be met</td>
+	</tr>
+</table>
 
 ### Domain-specific competencies
 
@@ -35,7 +57,3 @@ Some competencies are domain-specific. This means that the competency is only ap
 ### Examples
 
 Some competencies have one or more examples. The examples are purely illustrative, and will not apply to everyone. When working towards a competency, an engineer does not need to be meeting any of the examples given if they can provide evidence that they are meeting the competency in another way.
-
-### Evidence
-
-Engineers are expected to provide evidence that they are are meeting a competency when it comes to writing a promotions case. We expect a sentence or two, and an engineer's line manager should be ready to provide further detail if necessary. A copy of the <a href="https://docs.google.com/spreadsheets/d/1V0LIbCQtJsi2iowfJnRTDr4Na4LhNAlJ_UHl9dDQs00/edit" class="o-typography-link--external">Engineering Progression Tracker (Google Sheet)</a> is useful for keeping track of progress.


### PR DESCRIPTION
This PR updates the "how-to-use" guide to indicate that not all
competencies must be met for an engineer to be considered for promotion.
This is the opposite to the way we've been responding to certain issues
and questions, and we'll be updating our responses to those once this
wording has been agreed on.

We're making this change for a couple of reasons:

  1. This is a less big jump for people from the current competencies
     matrix to the new one - it's a lot to expect particularly in the
     first trials of a new system

  2. We've had feedback on several competencies that they are not easily
     meetable by engineers in certain teams. We don't want to remove or
     relax too many competencies, and allowing them to be marked as not
     met but with an explanation helps to reduce edge-cases

  3. The messaging used by JK and the tech directors so far indicates
     that not all competencies must be met. The "how-to-use" guide was
     directly contradicting this

This is one of the larger changes to the messaging on the site and in
this repo since we announced the alpha, and so we anticipate a few
questions and comments. Please let us know what you think of the change