### PR TITLE
Create a clearer thread around presenting work

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -251,7 +251,7 @@
 # Junior to Mid, Leadership
 
 - id: 88c876aa-fce5-414b-b0c0-b1b7602beea8
-  summary: Presents their work to a product owner or tech lead. Clearly communicates technical concepts to non-technical colleagues.
+  summary: Presents their own work clearly to a product owner or tech lead
   examples: []
   description: null
   level: junior-to-mid
@@ -526,14 +526,6 @@
 
 # Mid to Senior 1, Leadership
 
-- id: c0cf9ac1-a25f-44ed-818e-ba0895dc5e02
-  summary: Presents aspects of their work to stakeholders
-  examples: []
-  description: null
-  level: mid-to-senior1
-  area: leadership
-  domain: null
-
 - id: f34273e2-3d81-4bde-8c23-0217e71b3536
   summary: Influences a community of practice
   examples:
@@ -572,7 +564,7 @@
   domain: null
 
 - id: 11d32a45-ea1e-411f-a810-12a4f0b8ddb9
-  summary: Presents their work to stakeholders. Clearly communicates technical concepts to non-technical colleagues.
+  summary: Presents their own work clearly to stakeholders
   examples: []
   description: null
   level: mid-to-senior1
@@ -707,7 +699,7 @@
 # Senior 1 to Senior 2, Leadership
 
 - id: 60fc5d33-a5ee-4c1b-a370-e0c8a6b8ada9
-  summary: Presents the team's work beyond their immediate team to stakeholders. Clearly communicates technical concepts to non-technical colleagues
+  summary: Presents their team's work to others in the business
   examples:
     - Speaks at the Technology All Hands
     - Writes one-pagers to explain technical descisions


### PR DESCRIPTION
I've updated the language for the set of competencies that relate to
an engineer presenting their work to people. I've removed the line:

> Clearly communicates technical concepts to non-technical colleagues

This was repeated for each competency and relates more to communication.
I'll address this separately.

I've also removed a duplicate competency from M->S1 leadership.

This work should hopefully address part of #96 and close #130.