### PR TITLE
Change wording about being the go-to person

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -473,7 +473,7 @@
   summary: Where appropriate, builds on other teams' work to solve problems
   examples:
     - Uses origami components to style a web page
-    - Records information about technical infrastructure in Biz Ops 
+    - Records information about technical infrastructure in Biz Ops
   description: null
   level: mid-to-senior1
   area: delivery
@@ -632,8 +632,10 @@
   domain: null
 
 - id: f3ac4fe5-c1ab-4fd2-b559-52d6a79e11d0
-  summary: Is the go-to person for a technology or system
-  examples: []
+  summary: Has a deep understanding and willingness to help others for a particular technology or product
+  examples:
+    - Responds to questions on Slack about a particular technology or product
+    - Provides thoughtful and in-depth feedback on Pull Requests that fall into their area of expertise
   description: null
   level: senior1-to-senior2
   area: technical


### PR DESCRIPTION
We had some really good feedback on this competency - that it encourages
people to become "key person dependencies" or that it encourages them
to "knowledge hoard"

Changing the wording on this to emphasise the knowledge sharing aspect
of being an expert. What good is an expert if they don't share their
expertise?

closes #117 