### PR TITLE
Wider Tech Strategy

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -603,7 +603,7 @@
   domain: null
 
 - id: 46c795d8-b684-4401-bf1e-45a31dd689cb
-  summary: Considers technical direction of their group or the wider department when coming up with technical solutions
+  summary: Considers the technical direction of their group or the wider department when coming up with technical solutions
   examples: 
     - Understands how their work feeds into their group's tech strategy
     - Can articulate and justify the overall cost of their technical solutions

--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -603,8 +603,11 @@
   domain: null
 
 - id: 46c795d8-b684-4401-bf1e-45a31dd689cb
-  summary: Considers wider tech strategy when coming up with technical solutions
-  examples: []
+  summary: Considers technical direction of their group or the wider department when coming up with technical solutions
+  examples: 
+    - Understands how their work feeds into their group's tech strategy
+    - Can articulate and justify the overall cost of their technical solutions
+    - Follows their group's Engineering Principles when building technical solutions  
   description: null
   level: senior1-to-senior2
   area: technical


### PR DESCRIPTION
Addresses https://github.com/Financial-Times/engineering-progression/issues/124 
Not all teams have a public strategy that engineers can refer to, so this tweaks the wording of the competency to be more inclusive and adds some examples.