### PR TITLE
Add some examples for hiring

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -327,7 +327,7 @@
 
 - id: 2c1289fe-3bf9-476b-981b-8af2d345d76a
   summary: Implements appropriate observability and monitoring when building a solution
-  examples: 
+  examples:
     - When adding a new dependency to a system, adds a healthcheck to monitor the dependency's state
     - Adds logging that is well-structured and captures useful information about the state of a system
     - Builds a Grafana dashboard that visualises normal and abnormal operation of a system
@@ -445,6 +445,11 @@
   examples:
     - Participates in hiring panels or technical interviews
     - Attends recruitment events
+    - Publicly shares links to open roles
+    - Goes for coffe with potential hires to talk about what working at the Financial Times is like
+    - Shares our work publicly, (through blogging, speaking, etc) to show the kinds of work we do here
+    - Reviews CVs
+    - Reviews tech tests
   description: null
   level: mid-to-senior1
   area: communication
@@ -609,10 +614,10 @@
 
 - id: 46c795d8-b684-4401-bf1e-45a31dd689cb
   summary: Considers the technical direction of their group or the wider department when coming up with technical solutions
-  examples: 
+  examples:
     - Understands how their work feeds into their group's tech strategy
     - Can articulate and justify the overall cost of their technical solutions
-    - Follows their group's Engineering Principles when building technical solutions  
+    - Follows their group's Engineering Principles when building technical solutions
   description: null
   level: senior1-to-senior2
   area: technical

--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -446,7 +446,7 @@
     - Participates in hiring panels or technical interviews
     - Attends recruitment events
     - Publicly shares links to open roles
-    - Goes for coffe with potential hires to talk about what working at the Financial Times is like
+    - Goes for coffee with potential hires to talk about what working at the Financial Times is like
     - Shares our work publicly, (through blogging, speaking, etc) to show the kinds of work we do here
     - Reviews CVs
     - Reviews tech tests


### PR DESCRIPTION
The hiring pipeline goes all the way from showcasing our work so people
can see what we're up to and consider applying to actual interviews.
Add some more examples to help people understand what applies to meet
this competency.

closes #146 