### PR TITLE
Remove go-to person from summary

### DIFF
--- a/data/levels.yml
+++ b/data/levels.yml
@@ -31,8 +31,8 @@
     This influence could be through tech leading, line managing, mentoring, or leading
     projects outside of their day-to-day work. Senior 2 engineers are good at
     seeing ill-defined or difficult projects through to completion. They are great at
-    spotting issues and helping their team navigate them. Senior 2 engineers are
-    seen as the go-to person for a particular technology or product.
+    spotting issues and helping their team navigate them. Senior 2 engineers have a deep
+    understanding and willingness to help others for a particular technology or product.
 
 # Senior 2 to Principal
 - id: senior2-to-principal


### PR DESCRIPTION
In https://github.com/Financial-Times/engineering-progression/pull/142 we addressed the issue raised about go-to person being unclear. This updates the summary for the s1->s2 level to match. (it was raised again in the S2 workshop)