### PR TITLE
Remove unreasonable expectation for juniors

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -281,7 +281,6 @@
     - Draws people working remotely into planning conversations
     - Tactfully calls out exclusive or alienating behaviours from others
     - Organises a leaving collection for a colleague
-    - Makes a round of tea for the team
     - Documents team norms to help new starters
     - Checks in with team members who appear stressed
   description: null


### PR DESCRIPTION
This should not be considered a requirement to move from junior to senior (even as an example to boost team culture)
Please let us not expect our juniors to do a tea run for the team. 