### PR TITLE
Add examples to feedback competency

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -171,7 +171,9 @@
 
 - id: 79c4ecfd-7085-49c2-8a21-429b4a269c96
   summary: Regularly gives timely actionable feedback to colleagues
-  examples: []
+  examples:
+    - Emails positive feedback to a colleague's line manager, after the colleague was especially helpful.
+    - Notices that someone in the team has invited everyone to a meeting without an agenda. Asks them to add one so people know what the meeting is for and can prepare properly.
   description: null
   level: junior-to-mid
   area: communication


### PR DESCRIPTION
closes #181 

This competency sparked a lot of discussion. Quotes from the feedback
session:

* This one may be a bit more difficult because as a junior you may not
feel comfortable giving feedback to your colleagues if they are more
senior
* In my team there are 3 seniors and a junior and I would find it very
difficult to give feedback to a more senior member of staff.
* Maybe this is a cultural thing between different teams
Is this maybe a difficult competency for somebody who's more introverted
, or working on a much more senior-heavy team?

This commit adds two examples to clarify that:
- feedback doesn't need to be direct, it can go via a line manager
- feedback doesn't need to be negative, positive feedback is really
important too
- feedback can be really small - like asking someone to add an agenda
to a meeting