### PR TITLE
mid ->S1 Has responsibility for others’ development

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -608,8 +608,11 @@
   domain: null
 
 - id: 5e7b6a79-c553-4852-a5eb-97a6550f59da
-  summary: Has responsibility for others’ development through mentoring or line management
-  examples: []
+  summary: Has responsibility for others’ professional development
+  examples: 
+    - Is a line manager or mentor
+    - Is a designated buddy to a new starter
+    - Regularly meets up with more junior peers to provide guidance
   description: null
   level: mid-to-senior1
   area: leadership


### PR DESCRIPTION
Addresses https://github.com/Financial-Times/engineering-progression/issues/225

@mark-barnes I’ve stopped short of making it completely informal (added words like `regularly` and `designated`). I feel this competency should be met with more than having helped someone once, for example.

Someone at mid-level who’s about to go to S1 will have enough junior and other more recent mid-level folk to support, beyond their day-to-day duties of collaborating with peers.