### PR TITLE
Fix the FAQ page

### DIFF
--- a/site/pages/faq.md
+++ b/site/pages/faq.md
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: FAQ on the FT's engineering competencies
-permalink: /docs/faq
+permalink: /docs/faq/
 layout: o-layout-docs
 ---
 

--- a/site/pages/join-the-working-group.md
+++ b/site/pages/join-the-working-group.md
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: Join the engineering competencies working group
-permalink: /docs/join-the-working-group
+permalink: /docs/join-the-working-group/
 layout: o-layout-docs
 ---
 


### PR DESCRIPTION
Permalinks need a trailing slash, this is for consistency and also
because there was some weirdness with GitHub pages redirects. Without
the slash then the canonical URL is `/docs/faq.html` rather than
`/docs/faq`.