### PR TITLE
Simplify the "Ambassador" competency

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -610,7 +610,7 @@
   domain: null
 
 - id: 0777c050-8008-4e17-a437-f8de0be3bd55
-  summary: Is an ambassador for their team across FT technology and colleagues in the rest of the business
+  summary: Is an ambassador for their team across FT technology
   examples:
     - Positively represents their team in interactions with other people by seeking to understand their perspectives, values and needs
     - Consistently contributes to their team being positively perceived by stakeholders (or by other engineering teams to which they provide support)


### PR DESCRIPTION
We decided to leave the word "ambassador" in, but remove the second
part. This resolves #193