### PR TITLE
Make the competency pages print-friendly

### DIFF
--- a/site/_includes/competency-list.html
+++ b/site/_includes/competency-list.html
@@ -6,11 +6,16 @@
 
 		<p>{{level.summary}}</p>
 
+		<!--
+		We repeat the paragraph here because one is not optimised for printing
+		and the other is (e.g. labelling the engineering progression link as a URL).
+		People viewing on a screen or using assistive tech will not see or hear the
+		second paragraph
+		-->
 		<p class="screen-only">
 			<em>The competencies for {{level.name}} are outlined below. Before reviewing them, it is helpful to
 			<a href="/competencies/how-to-use/">review how to use these competencies</a>.</em>
 		</p>
-
 		<p class="print-only" aria-hidden="true">
 			<em>The competencies for {{level.name}} are outlined below. You can find more information on using these
 			competences on the Engineering Progression website: <a href="https://engineering-progression.ft.com/">https://engineering-progression.ft.com/</a>.</em>
@@ -43,7 +48,15 @@
 											</ul>
 										{% endif %}
 									</td>
-									<td class="competency-table__evidence" aria-hidden="true"></td>
+									<!--
+									This additional column is hidden by default, but is visible when
+									the page is printed. The inner div is used to set a minimum height
+									for evidence columns because `min-height` does not work on table
+									rows or cells
+									-->
+									<td class="competency-table__evidence" aria-hidden="true">
+										<div class="competency-table__evidence-inner"></div>
+									</td>
 								</tr>
 							{% endif %}
 						{% endfor %}

--- a/site/_includes/competency-list.html
+++ b/site/_includes/competency-list.html
@@ -6,37 +6,51 @@
 
 		<p>{{level.summary}}</p>
 
-		<p>
+		<p class="screen-only">
 			<em>The competencies for {{level.name}} are outlined below. Before reviewing them, it is helpful to
 			<a href="/competencies/how-to-use/">review how to use these competencies</a>.</em>
 		</p>
 
-		{% for area in areas %}
-			{% assign area_lower_case = area | downcase %}
+		<p class="print-only" aria-hidden="true">
+			<em>The competencies for {{level.name}} are outlined below. You can find more information on using these
+			competences on the Engineering Progression website: <a href="https://engineering-progression.ft.com/">https://engineering-progression.ft.com/</a>.</em>
+		</p>
 
-			<h2 id="{{area_lower_case}}">{{area}}</h2>
-
-			<ul class="o-layout__unstyled-element competency-list">
-				{% for competency in site.data.competencies %}
-					{% if competency.level == level.id and competency.area == area_lower_case %}
-						<li class="competency-list__competency">
-							{% assign example-count = competency.examples | size %}
-							<p class="o-layout__unstyled-element competency-list__summary">
-								{{competency.summary}}{% if example-count > 0 %}, e.g.{% endif %}
-							</p>
-							{% if example-count > 0 %}
-								<ul class="o-layout__unstyled-element competency-list__examples">
-									{% for example in competency.examples %}
-										<li>{{example}}</li>
-									{% endfor %}
-								</ul>
+		<div class="o-layout__main__full-span">
+			<table class="o-table o-table--horizontal-lines competency-table" data-o-component="o-table">
+				<thead>
+					<tr>
+						<th scope="col" role="columnheader">Area</th>
+						<th scope="col" role="columnheader">Competency</th>
+						<th scope="col" role="columnheader" class="competency-table__evidence" aria-hidden="true">Evidence / Notes</th>
+					</tr>
+				</thead>
+				<tbody>
+					{% for area in areas %}
+						{% assign area_lower_case = area | downcase %}
+						{% for competency in site.data.competencies %}
+							{% if competency.level == level.id and competency.area == area_lower_case %}
+								<tr>
+									{% assign example-count = competency.examples | size %}
+									<td>{{area}}</td>
+									<td>
+										{{competency.summary}}{% if example-count > 0 %}, e.g.{% endif %}
+										{% if example-count > 0 %}
+											<ul class="o-layout__unstyled-element competency-table__examples">
+												{% for example in competency.examples %}
+													<li>{{example}}</li>
+												{% endfor %}
+											</ul>
+										{% endif %}
+									</td>
+									<td class="competency-table__evidence" aria-hidden="true"></td>
+								</tr>
 							{% endif %}
-						</li>
-					{% endif %}
-				{% endfor %}
-			</ul>
-
-		{% endfor %}
+						{% endfor %}
+					{% endfor %}
+				</tbody>
+			</table>
+		</div>
 
 	{% endif %}
 {% endfor %}

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -34,7 +34,7 @@
 			display: none !important;
 		}
 	</style>
-	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-typography@^5.8.0,o-layout@^3.0.0-beta.2,o-header-services@^3.2.9,o-footer-services@^2.0.3,o-syntax-highlight@^1.4.0,o-message@^3.1.0,o-table@^6.9.0,o-labels@^4.2.2&brand=internal" />
+	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-typography@^5.8.0,o-layout@^3.2.0,o-header-services@^3.2.9,o-footer-services@^2.0.3,o-syntax-highlight@^1.4.0,o-message@^3.1.0,o-table@^7.4.0,o-labels@^4.2.2&brand=internal" />
 	<link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}" />
 
 	<!-- Site links -->
@@ -50,7 +50,7 @@
 				var s = document.getElementsByTagName('script')[0];
 				s.parentNode.insertBefore(o, s);
 			}
-		}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-typography@^5.8.0,o-layout@^3.0.0-beta.2,o-header-services@^3.2.9,o-footer-services@^2.0.3,o-syntax-highlight@^1.4.0,o-message@^3.1.0,o-table@^6.9.0'));
+		}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-typography@^5.8.0,o-layout@^3.2.0,o-header-services@^3.2.9,o-footer-services@^2.0.3,o-syntax-highlight@^1.4.0,o-message@^3.1.0,o-table@^7.4.0'));
 	</script>
 
 </head>

--- a/site/css/main.scss
+++ b/site/css/main.scss
@@ -3,22 +3,41 @@
 ---
 @charset "utf-8";
 
-// Competency list styles (for individual level pages)
-.competency-list {
-	list-style: none;
-	padding-left: 0;
-	margin-top: 0;
-	margin-bottom: 1em;
+// General print styles
+.print-only {
+	display: none;
 }
-.competency-list__competency {
-	margin-bottom: 1em;
+@media print {
+	.print-only {
+		display: block;
+	}
+	.screen-only {
+		display: none;
+	}
+	@page {
+		size: portrait;
+	}
+	.o-layout {
+		display: block;
+	}
+	.o-layout__header,
+	.o-layout__footer,
+	.o-layout__sidebar {
+		display: none;
+	}
 }
-.competency-list__summary {
-	margin: 0;
-	font-weight: 500;
+
+// Competency table styles (for print CSS)
+.competency-table__evidence {
+	display: none;
+	@media print {
+		display: table-cell;
+		width: 30%;
+	}
 }
-.competency-list__examples {
+.competency-table__examples {
 	margin-bottom: 0;
+	margin-top: .5em;
 	list-style: disc;
 	font-style: italic;
 }

--- a/site/css/main.scss
+++ b/site/css/main.scss
@@ -15,7 +15,7 @@
 		display: none;
 	}
 	@page {
-		size: portrait;
+		size: landscape;
 	}
 	.o-layout {
 		display: block;
@@ -32,7 +32,12 @@
 	display: none;
 	@media print {
 		display: table-cell;
-		width: 30%;
+		width: 40%;
+	}
+}
+.competency-table__evidence-inner {
+	@media print {
+		min-height: 5em;
 	}
 }
 .competency-table__examples {


### PR DESCRIPTION
This also switches the screen view to a table, which is easier to scan
and sort. The page now looks like this:

![Junior to mid screen grab](https://user-images.githubusercontent.com/138944/64102506-0bd03c80-cd68-11e9-97ae-66eca8b297eb.png)

And the print version now looks like this:

<img width="529" alt="Junior to mid print grab" src="https://user-images.githubusercontent.com/138944/64102648-489c3380-cd68-11e9-9ea1-a6f6840bfd5b.png">

This resolves #92
