### PR TITLE
Add examples for "learns and improves" competency

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -47,17 +47,6 @@
   area: technical
   domain: null
 
-- id: 22c2a49e-4e2e-4a63-a09e-57a0efce7e38
-  summary: Learns and improves independently
-  examples:
-    - Sees some code that they don't understand, and researches how it works
-    - Takes some time between meetings to read about technology
-    - Uses 10% time to learn how to use a new tool
-  description: null
-  level: junior-to-mid
-  area: technical
-  domain: null
-
 - id: f66d122f-bd81-4b57-8b4a-78f00a11934c
   summary: Reuses existing code
   examples:
@@ -162,19 +151,6 @@
 - id: 458cfd7f-b621-462e-ad7f-90870e1d5cfc
   summary: Writes clear tickets, issues and bug reports that contain the necessary amount of detail to be easily picked up by other engineers
   examples: []
-  description: null
-  level: junior-to-mid
-  area: communication
-  domain: null
-
-- id: f6e9efd1-7d55-439b-8f7d-c50829e48879
-  summary: Takes ownership of personal development
-  examples:
-    - Finds a training course and takes it
-    - Studies for and attains a technical certification
-    - Proactively learns how to use a new tool/language feature
-    - Attends meet-ups or conferences
-    - Reads blog posts about technology
   description: null
   level: junior-to-mid
   area: communication
@@ -337,6 +313,20 @@
     - Had done a secondment to Operations and Reliability
     - Works in the Interactive Graphics team and collaborates with someone from Editorial on a project
     - Works in Internal Products and collaborates with the Origami team on a new feature in a component
+  description: null
+  level: junior-to-mid
+  area: leadership
+  domain: null
+  
+- id: 22c2a49e-4e2e-4a63-a09e-57a0efce7e38
+  summary: Takes ownership of their personal development
+  examples:
+    - Sees some code that they don't understand, and researches how it works
+    - Proactively learns how to use a new tool/language feature
+    - Reads blog posts about technology
+    - Studies for and attains a technical certification
+    - Finds a training course and takes it
+    - Attends meet-ups or conferences
   description: null
   level: junior-to-mid
   area: leadership

--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -49,7 +49,10 @@
 
 - id: 22c2a49e-4e2e-4a63-a09e-57a0efce7e38
   summary: Learns and improves independently
-  examples: []
+  examples:
+    - Sees some code that they don't understand, and researches how it works
+    - Takes some time between meetings to read about technology
+    - Uses 10% time to learn how to use a new tool
   description: null
   level: junior-to-mid
   area: technical


### PR DESCRIPTION
Adding this helped me spot a potential overlap in competencies for
Junior to Mid.

There is this competency in techical (examples are new):

```yaml
id: 22c2a49e-4e2e-4a63-a09e-57a0efce7e38
summary: Learns and improves independently
  - Sees some code that they don't understand, and researches how it works
  - Takes some time between meetings to read about technology
  - Uses 10% time to learn how to use a new tool
```

And this one in communication:

```yaml
id: f6e9efd1-7d55-439b-8f7d-c50829e48879
summary: Takes ownership of personal development
examples:
  - Finds a training course and takes it
  - Studies for and attains a technical certification
  - Proactively learns how to use a new tool/language feature
  - Attends meet-ups or conferences
  - Reads blog posts about technology
```

When writing examples for the first, I found it quite difficult to keep
these feeling like distinct competencies. Thoughts?