### PR TITLE
Add examples for "writes clear tickets" competency

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -157,8 +157,11 @@
   domain: null
 
 - id: 458cfd7f-b621-462e-ad7f-90870e1d5cfc
-  summary: Writes clear tickets, issues and bug reports that contain the necessary amount of detail to be easily picked up by other engineers
-  examples: []
+  summary: Writes clear tickets, issues and bug reports that contain the necessary amount of detail to be picked up by other engineers
+  examples:
+    - Adds links to the pages that are affected by a bug
+    - Writes steps to reproduce an issue that they've found
+    - Adds screenshots to a ticket to help explain a display bug
   description: null
   level: junior-to-mid
   area: communication


### PR DESCRIPTION
This competency is missing some examples, let me know what you think.
I couldn't think of an example for writing a feature ticket that didn't
sound like it should be the job of someone in product or delivery.

I've also removed the word "easily" from this competency, as this goes
against our [tone and language guide](https://github.com/Financial-Times/engineering-progression/blob/master/docs/language.md#avoid-trivialisation).

```yaml
id: 458cfd7f-b621-462e-ad7f-90870e1d5cfc
summary: Writes clear tickets, issues and bug reports that contain the necessary amount of detail to be picked up easily by other engineers
```