### PR TITLE
Add examples to "presents their work" competency

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -200,7 +200,10 @@
 
 - id: 88c876aa-fce5-414b-b0c0-b1b7602beea8
   summary: Presents their own work clearly to a product owner or tech lead
-  examples: []
+  examples:
+    - Talks about their progress in standup without going into deep technical detail
+    - Explains their approach to a technical problem to their tech lead
+    - Gives a live demo of a feature that they worked on to their team
   description: null
   level: junior-to-mid
   area: communication


### PR DESCRIPTION
This competency is missing some examples, let me know what you think:

```yaml
id: 88c876aa-fce5-414b-b0c0-b1b7602beea8
summary: Presents their own work clearly to a product owner or tech lead
```