### PR TITLE
Fix examples of team priorities

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -839,11 +839,11 @@
 
 - id: 45780158-375a-421b-a89a-97d32e61cdba
   summary:  Shapes the medium to long term priorities of their team
+  examples:
     - Finds commonalities between small feature ideas in order to form them into larger, coherent technical challenges for the team
     - Champions turning things off into order to have capacity to work on new things
     - Argues for and forms a feature team to tackle a shared problem with other areas of the business
     - Writes a realistic roadmap in collaboration with a product owner and delivery lead
-  examples: []
   description: null
   level: senior1-to-senior2
   area: leadership


### PR DESCRIPTION
These have been added as a long string on the summary rather than a list
of examples. This makes the formatting wonky when they are displayed.

<img width="666" alt="Screenshot 2019-09-10 at 15 12 07" src="https://user-images.githubusercontent.com/35035/64621319-64917c00-d3dd-11e9-8cee-007ecf7df6a8.png">
