### PR TITLE
Update the Slack channel name

### DIFF
--- a/site/_data/contact.yml
+++ b/site/_data/contact.yml
@@ -1,4 +1,6 @@
 
 # Working group contact details
 email: engineering-progression@ft.com
-slack: engineer-progression
+slack:
+  name: engineering-progression-framework
+  url: https://app.slack.com/client/T025C95MN/CGQ1XSNBB

--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -3,7 +3,7 @@
 	<div class="o-footer-services__container">
 		<div class="o-footer-services__wrapper o-footer-services__wrapper--top">
 			<a class="o-footer-services__icon-link o-footer-services__icon-link--github" href="{{site.github.repository_url}}">View project on GitHub</a>
-			<a class="o-footer-services__icon-link o-footer-services__icon-link--slack" href="https://financialtimes.slack.com/messages/{{site.data.contact.slack}}">#{{site.data.contact.slack}}</a>
+			<a class="o-footer-services__icon-link o-footer-services__icon-link--slack" href="{{site.data.contact.slack.url}}">#{{site.data.contact.slack.name}}</a>
 			<p class="o-footer-services__content">Get in touch at <a href="mailto:{{site.data.contact.email}}">{{site.data.contact.email}}</a> for help or advice. Feel free to
 				<a class="o-footer-services__content--external"   href='{{site.github.repository_url}}/edit/master/site/{{page.path}}'>suggest an edit to this page</a>.</p>
 		</div>

--- a/site/pages/home.html
+++ b/site/pages/home.html
@@ -60,8 +60,8 @@ layout: o-layout-landing
 			<h2>Contact</h2>
 			<ul>
 				<li>To suggest and discuss improvements, open an <a href="{{site.github.repository_url}}/issues/new" class="o-typography-link--external">issue</a> or pull request in GitHub</li>
-				<li>For general enquiries, use the <a href="https://financialtimes.slack.com/messages/{{site.data.contact.slack}}" class="o-typography-link--external">#{{site.data.contact.slack}}</a> slack channel</li>
-				<li>Email <a href="mailto:{{site.data.contact.email}}">{{site.data.contact.email}}</a> for anything you'd like to discuss privately</li>	
+				<li>For general enquiries, use the <a href="{{site.data.contact.slack.url}}" class="o-typography-link--external">#{{site.data.contact.slack.name}}</a> slack channel</li>
+				<li>Email <a href="mailto:{{site.data.contact.email}}">{{site.data.contact.email}}</a> for anything you'd like to discuss privately</li>
 			</ul>
 		</div>
 


### PR DESCRIPTION
This now matches the new channel name in Slack.

I've also split the slack site variable into name and URL so we can
avoid a redirect.