### PR TITLE
Add Fastly WAF as an option

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -1,4 +1,3 @@
-
 # Junior to Mid, Technical
 
 - id: 4029f7b4-0c42-4867-818b-c03049a07de1
@@ -122,7 +121,6 @@
   area: technical
   domain: null
 
-
 # Junior to Mid, Communication
 
 - id: 6a019e95-20ab-4af5-a42a-727274eec0d8
@@ -192,7 +190,6 @@
   level: junior-to-mid
   area: communication
   domain: null
-
 
 # Junior to Mid, Delivery
 
@@ -272,7 +269,6 @@
   area: delivery
   domain: null
 
-
 # Junior to Mid, Leadership
 
 - id: c9cf0d0e-2695-479c-97ef-4457ae36aeb6
@@ -328,7 +324,7 @@
   level: junior-to-mid
   area: leadership
   domain: null
-  
+
 - id: 22c2a49e-4e2e-4a63-a09e-57a0efce7e38
   summary: Takes ownership of their personal development
   examples:
@@ -397,6 +393,7 @@
     - Applies security patches to an operating system
     - Protecting public API endpoints
     - Articulates security risks/benefits when evaluating third party software
+    - Uses a Fastly WAF to protect from malicious requests.
   description: null
   level: mid-to-senior1
   area: technical
@@ -608,7 +605,6 @@
   area: delivery
   domain: null
 
-
 # Mid to Senior 1, Leadership
 
 - id: f34273e2-3d81-4bde-8c23-0217e71b3536
@@ -768,7 +764,6 @@
   area: communication
   domain: null
 
-
 # Senior 1 to Senior 2, Delivery
 
 - id: 877d7313-d6de-44ae-80b4-5ed094ddf39a
@@ -801,7 +796,6 @@
   level: senior1-to-senior2
   area: delivery
   domain: null
-
 
 # Senior 1 to Senior 2, Leadership
 
@@ -838,7 +832,7 @@
   domain: null
 
 - id: 45780158-375a-421b-a89a-97d32e61cdba
-  summary:  Shapes the medium to long term priorities of their team
+  summary: Shapes the medium to long term priorities of their team
   examples:
     - Finds commonalities between small feature ideas in order to form them into larger, coherent technical challenges for the team
     - Champions turning things off into order to have capacity to work on new things


### PR DESCRIPTION
### Why

When covering the options in Mid-Senior1, I noticed there was no mention of CDN's or WAF as a part of security protection for our apps. This seems like a reasonable addition considering the FT has widely adopted Fastly.

### What Changed

Added a Fastly WAF example for the `security attack vector` competency.