### PR TITLE
Add supporting URLs to the schema

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -5,6 +5,7 @@
   examples:
     - Keeps local tools up to date
     - Follows instructions to get software projects running locally
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: technical
@@ -14,6 +15,7 @@
   summary: Uses version control to manage development workflow
   examples:
     - "Git specific example: clone, branch, add, commit, push, rebase"
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: technical
@@ -25,6 +27,7 @@
     - Takes a feature from their team backlog and writes the code for that feature
     - Automates a regular task using Python
     - Writes a CloudFormation template
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: technical
@@ -33,6 +36,7 @@
 - id: 4db41452-c2c7-40bf-87b1-a2d8ed6f902a
   summary: Writes automated unit and end to end tests for features
   examples: []
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: technical
@@ -41,6 +45,7 @@
 - id: 2385d7ee-64c1-45de-b1d9-18050fba9d44
   summary: Fixes or updates tests when changing existing code
   examples: []
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: technical
@@ -53,6 +58,7 @@
     - Uses a node package in project
     - Integrates with proprietary software packages
     - Uses Origami
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: technical
@@ -64,6 +70,9 @@
     - Fixes vulnerabilities in dependencies raised by Snyk
     - Fixes vulnerabilities raised by the cyber security team
     - Doesn't introduce vulnerabilities outlined in the Open Web Application Security Project (OWASP) top 10
+  supportingUrls:
+    - label: Open Web Application Security Project
+      url: https://www.owasp.org/
   description: null
   level: junior-to-mid
   area: technical
@@ -74,6 +83,7 @@
   examples:
     - Fixes broken tests caused by changes in their code
     - Uses logging or a debugger to find the root cause when a new feature is not working as expected
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: technical
@@ -85,6 +95,7 @@
     - Notices that an AWS region is down so fails over to another region
     - Responds to alerts for services in production by investigating errors and beginning remedial action
     - Works as home teams' "ops cop", liaising with Operations and Reliability to restore a service
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: technical
@@ -98,6 +109,7 @@
     - Makes config changes in CircleCI
     - Adds a build status badge to their project
     - Promotes an app from staging to production in Heroku
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: technical
@@ -107,6 +119,7 @@
   summary: Uses monitoring (but doesn't necessarily implement monitoring)
   examples:
     - Pingdom, grafana
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: technical
@@ -117,6 +130,7 @@
   examples:
     - Weighs up the benefits of making code more abstract vs specific
     - Reasons about making an API call from the client or from the server - it's easier from the client but core experience will be worse
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: technical
@@ -133,6 +147,7 @@
     - Writes good commit messages that explain why a change was made
     - Puts line comments around any 'magic' bits of code
     - Writes and updates runbooks for services they work on
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: communication
@@ -144,6 +159,7 @@
     - Reviews pull requests and gives actionable empathetic feedback
     - Recognises when a more senior colleague has not given enough detail in an explanation, and asks for clarification
     - Gives realtime feedback in mob programming sessions
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: communication
@@ -155,6 +171,7 @@
     - Adds links to the pages that are affected by a bug
     - Writes steps to reproduce an issue that they've found
     - Adds screenshots to a ticket to help explain a display bug
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: communication
@@ -166,6 +183,7 @@
     - Implements requested changes on a pull request
     - Responds to comments on a Google document
     - Receives feedback from the team that sometimes they don't seem well prepared for morning stand-ups, so takes 5 minutes before stand-ups to gather thoughts about what the status of their work is
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: communication
@@ -176,6 +194,7 @@
   examples:
     - Emails positive feedback to a colleague's line manager, after the colleague was especially helpful.
     - Notices that someone in the team has invited everyone to a meeting without an agenda. Asks them to add one so people know what the meeting is for and can prepare properly.
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: communication
@@ -187,6 +206,7 @@
     - Talks about their progress in standup without going into deep technical detail
     - Explains their approach to a technical problem to their tech lead
     - Gives a live demo of a feature that they worked on to their team
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: communication
@@ -199,6 +219,7 @@
   examples:
     - Picks the story from the top of a prioritised backlog rather than picking the one that most interests them
     - Creates tickets to capture non-trivial tech debt, rather than getting side-tracked by things not needed to complete the current task
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: delivery
@@ -210,6 +231,7 @@
     - Attends customer based user research for a feature being worked on
     - Sets up a testing session with peers for a new bit of tooling
     - Finds a common pain point among teammates and proposes/builds a solution for it
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: delivery
@@ -220,6 +242,7 @@
   examples:
     - Turns a user story into a technical implementation in production
     - Raises blockers in timely way
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: delivery
@@ -231,6 +254,7 @@
     - Pairs with the designer who worked on visuals or wire-frames for a feature
     - Sits with their product owner to discuss some edge-cases in a feature
     - Helps to debug a cross-browser issue with a tester
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: delivery
@@ -239,6 +263,7 @@
 - id: 385be187-5aaa-493b-a663-3b8ec7a04d7f
   summary: Regularly contributes openly to team meetings and encourages others to do so
   examples: []
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: delivery
@@ -247,6 +272,7 @@
 - id: a0c27510-41d9-4a34-98d9-3b49b0ef8056
   summary: Regularly communicates the status of work
   examples: []
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: delivery
@@ -255,6 +281,7 @@
 - id: 168c5839-8070-4bb1-a0fa-b26d1267e791
   summary: Asks for help or clarification on tasks when required
   examples: []
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: delivery
@@ -265,6 +292,7 @@
   examples:
     - Moves tickets to done column when they are complete
     - Goes to stand-ups and communicates progress
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: delivery
@@ -275,6 +303,7 @@
 - id: c9cf0d0e-2695-479c-97ef-4457ae36aeb6
   summary: Knows who their project's stakeholders are
   examples: []
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: leadership
@@ -283,6 +312,7 @@
 - id: ac489603-aa6f-48a7-b89b-25b97ffdb541
   summary: Acts with integrity, honesty and accountability
   examples: []
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: leadership
@@ -297,6 +327,7 @@
     - Organises a leaving collection for a colleague
     - Documents team norms to help new starters
     - Checks in with team members who appear stressed
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: leadership
@@ -308,6 +339,7 @@
     - Pairs on a feature with a more junior colleague
     - Helps onboard a new hire, acting as their go-to person for questions
     - Comes back from a conference and shares their learnings with others
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: leadership
@@ -321,6 +353,7 @@
     - Had done a secondment to Operations and Reliability
     - Works in the Interactive Graphics team and collaborates with someone from Editorial on a project
     - Works in Internal Products and collaborates with the Origami team on a new feature in a component
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: leadership
@@ -335,6 +368,7 @@
     - Studies for and attains a technical certification
     - Finds a training course and takes it
     - Attends meet-ups or conferences
+  supportingUrls: []
   description: null
   level: junior-to-mid
   area: leadership
@@ -350,6 +384,7 @@
     - Data is retained only for as long as it is needed
     - Dummy/fictional data is used in staging environments and in tests
     - Suppliers don't get access to data unless they have gone through the Procurement Management Application process
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -361,6 +396,7 @@
     - When adding a new dependency to a system, adds a healthcheck to monitor the dependency's state
     - Adds logging that is well-structured and captures useful information about the state of a system
     - Builds a Grafana dashboard that visualises normal and abnormal operation of a system
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -371,6 +407,7 @@
   examples:
     - Can choose between similar Node libraries evaluating code quality, ease of integration, future maintenance, and security concerns
     - May be involved in evaluating paid-for third party supplier code
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -381,6 +418,7 @@
   examples:
     - Takes proactive action when an incident is reported on a system they support and resolves it satisfactorily
     - "Responds to critical issues raised in #ft-tech-incidents taking the initiative to fix them and reports back"
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -395,6 +433,7 @@
     - Protecting public API endpoints
     - Articulates security risks/benefits when evaluating third party software
     - Uses Fastly WAF to protect from malicious requests
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -407,6 +446,7 @@
     - When pressed for time, focuses on ensuring test coverage of the most critical system functionality
     - Manages technical debt, understands consequences of technical debt vs the cost of fixing it and acts accordingly
     - Can explain when something is worth refactoring even when it will impact the speed of delivery
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -416,6 +456,7 @@
   summary: Delivers high quality code and solutions
   examples:
     - Refactors solutions to improve clarity and maintainability
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -426,6 +467,7 @@
   examples:
     - Implements tooling to enforce high standards
     - Reviews pull requests fairly & critically in such away that team members produce better code
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -435,6 +477,7 @@
   summary: Regularly and independently debugs and fixes bugs regardless of origin
   examples:
     - Picks up and debugs an urgent issue that comes in to the team, despite having not written the code originally
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -445,6 +488,7 @@
   examples:
     - Combines multiple data sources in a feature, caching, polling etc as appropriate to cope with problems in downstream services
     - Adds healthchecks to a system that detect different ways in which it can fail
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -454,6 +498,7 @@
   summary: Chooses the appropriate tool, technology or software for a task
   examples:
     - If starting a new project, uses tools already understood by the team unless there is an agreed good reason to change
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -466,6 +511,7 @@
     - Publishes a new origami component that uses other components
     - Implements a CDN / gateway that routes to a suite of underlying microservices
     - Designs and implements a build pipeline
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -477,6 +523,7 @@
     - Understands how their work feeds into their group's tech strategy
     - Can articulate and justify the total cost of ownership of their technical solutions
     - Follows their group's Engineering Principles when building technical solutions
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: technical
@@ -491,6 +538,7 @@
     - Teaches more junior engineers
     - Creates diagrams to document how the different parts of systems interact
     - Presents their own work clearly to stakeholders
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: communication
@@ -501,6 +549,7 @@
   examples:
     - Runs meetings with clear agendas and outcomes
     - Obtains wide feedback on technical proposals and takes ownership of seeing it through
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: communication
@@ -516,6 +565,7 @@
     - Shares our work publicly, (through blogging, speaking, etc) to show the kinds of work we do here
     - Reviews CVs
     - Reviews tech tests
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: communication
@@ -526,6 +576,7 @@
 - id: c6bcfbd3-550f-4902-8c9a-bd6e9c77d67b
   summary: Prioritises technical work for the team (usually with others)
   examples: []
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: delivery
@@ -535,6 +586,7 @@
   summary: Breaks down large complex technical proposals into discrete tasks
   examples:
     - Creates the user stories for the ticket with a delivery lead
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: delivery
@@ -543,6 +595,7 @@
 - id: 850dda3f-df42-4187-a72b-aed1023b7abd
   summary: Communicates team/work's status upwards to a Principal or Technical Director
   examples: []
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: delivery
@@ -553,6 +606,7 @@
   examples:
     - Uses origami components to style a web page
     - Uses Biz Ops as a source of system data rather than creating a new system registry
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: delivery
@@ -563,6 +617,7 @@
   examples:
     - Reviews pull requests
     - Suggests someone to talk to eg “[X] knows the most about [technology Y], you could ask them”
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: delivery
@@ -572,6 +627,7 @@
   summary: Tackles simple cross team technical issues
   examples:
     - Notices a tool used by lots of teams has broken, identifies the problem and fixes (or reports it to the owner of the tool)
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: delivery
@@ -582,6 +638,7 @@
   examples:
     - Attends cross team meetings
     - Asks other teams for input and opinions on decisions that affect them
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: delivery
@@ -593,6 +650,7 @@
     - Updates the scrum process to fit the changing needs of the team
     - Champions technical issues that affect delivery such as release cycles, dealing with tech debt and bug fixes
     - Encourages other engineers to participate in agile team rituals
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: delivery
@@ -601,6 +659,7 @@
 - id: 7ccc5fac-5da2-451e-8043-af2fd880fcf9
   summary: Manages, prioritises and communicates own workload
   examples: []
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: delivery
@@ -616,6 +675,7 @@
     - Gives a tech talk (internally or externally)
     - Writes a blog post
     - Shares industry relevant content/links with team members that may be interested
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: leadership
@@ -626,6 +686,7 @@
   examples:
     - Positively represents their team in interactions with other people by seeking to understand their perspectives, values and needs
     - Consistently contributes to their team being positively perceived by stakeholders (or by other engineering teams to which they provide support)
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: leadership
@@ -640,6 +701,7 @@
     - Pairs with more junior team members
     - Writes blog posts to share knowledge
     - Gives talks at meet-ups or conferences to share knowledge
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: leadership
@@ -651,6 +713,7 @@
     - Is a tech lead
     - Runs, or is on the organising team for a Guild
     - Leads on large features or stories
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: leadership
@@ -662,6 +725,7 @@
     - Gives a workshop on Git
     - Runs a regular 101 session for the rest of the business
     - More informal knowledge sharing through mentorship
+  supportingUrls: []
   description: null
   level: mid-to-senior1
   area: leadership
@@ -675,6 +739,7 @@
     - Can articulate why the overhead of using a third party system is worth it for their project
     - Decides to invest time in building a dashboard for stakeholders to reduce the number of queries they make to the team
     - Gathers relevant data to inform buy vs. build vs. blend discussions impacting their project
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: technical
@@ -685,6 +750,7 @@
   examples:
     - Investigates a drop in organic traffic from google, makes educated investigations into various aspects of the end to end system, consulting other domain experts along the way and keeping stakeholders aware of progress.
     - Investigates a discrepancy in reported ad traffic. Works with the ad ops team to narrow down scope of problem. Uses technical knowledge to consult logs for various systems. Identifies a fix and implements.
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: technical
@@ -696,6 +762,7 @@
     - Notices a lot of requests coming in to Ops Cops from Customer Support for an admin task that could be automated. Automates the task and works with the Customer Support team on how to use the new tool
     - While debugging an issue, traces the bug back to a shared library. Creates a patch for the bug and makes sure it is released.
     - Spots another team could benefit from using a security feature and helps them implement it
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: technical
@@ -704,6 +771,7 @@
 - id: 7b2bacf1-ba46-464d-94e3-dc6f7c5edeb0
   summary: Translates difficult business requirements into technical designs
   examples: []
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: technical
@@ -714,6 +782,7 @@
   examples:
     - Responds to questions on Slack about a particular technology or product
     - Provides thoughtful and in-depth feedback on Pull Requests that fall into their area of expertise
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: technical
@@ -725,6 +794,7 @@
     - Takes a proposal to the Technical Governance Group
     - Contributes to technical strategy work
     - Successfully leads the group-wide adoption of a particular technology
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: technical
@@ -737,6 +807,7 @@
   examples:
     - Articulates to a product owner how one third-party technical solution is better than another
     - Explains to a stakeholder how a technical incident in a system impacted the business
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: communication
@@ -749,6 +820,7 @@
     - Gathers feedback from the hiring panels and leads wash-up discussion on the candidate
     - Is accountable for making sure engineers review CV's and tech tests in a timely manner
     - Works to improve the quality of the interviews we conduct and the consistency of the code and CV reviews we do
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: communication
@@ -762,6 +834,7 @@
     - Writes a blog post about an aspect of the team's work
     - Writes a monthly update newsletter for stakeholders about recent releases
     - Makes sure new features are announced to interested parties (e.g. publishing on the appropriate slack channel, sending a release email)
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: communication
@@ -772,6 +845,7 @@
 - id: 877d7313-d6de-44ae-80b4-5ed094ddf39a
   summary: Takes a stakeholder problem, investigates to understand it and proposes a solution
   examples: []
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: delivery
@@ -783,6 +857,7 @@
     - Manages the roll out of a new shared tool to multiple code repositories, identifying what work needs to be done, and finding teams to do the work
     - Finds a bug in a library that affects multiple teams, fixes the bug and works with teams to make sure everybody is able to upgrade
     - Finds a manual process slowing down multiple teams and automates it
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: delivery
@@ -795,6 +870,7 @@
     - Grooms backlog to make sure issues are ready to be picked up
     - Writes measurable team OKRs, aligned with the goals of their Group
     - Proactively unblocks others in their team
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: delivery
@@ -807,6 +883,7 @@
   examples:
     - Notices that people are not using Git as powerfully as they could so delivers a workshop for engineers on how to use Git's more advanced features.
     - Notices they are the only person that understands a particular area of the codebase, so writes and delivers a talk at a team meeting about that area.
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: leadership
@@ -818,6 +895,7 @@
     - Celebrates good work publicly and encourages the team to do the same
     - Spots problems between team members and helps to resolve them
     - Models inclusive behaviour to the rest of the team
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: leadership
@@ -829,6 +907,7 @@
     - Helps the team navigate disagreements over the best way to do things. Gets agreement and buy-in from engineers on a solution to a problem
     - Encourages team members to speak freely in retrospectives
     - Encourages team members to treat each other empathetically
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: leadership
@@ -841,6 +920,7 @@
     - Champions turning things off into order to have capacity to work on new things
     - Argues for and forms a feature team to tackle a shared problem with other areas of the business
     - Writes a realistic roadmap in collaboration with a product owner and delivery lead
+  supportingUrls: []
   description: null
   level: senior1-to-senior2
   area: leadership

--- a/site/pages/docs-api.md
+++ b/site/pages/docs-api.md
@@ -30,6 +30,16 @@ A Competency entity represents a single engineering competency, they look like t
 	// supporting examples
 	"examples": [String],
 
+	// An array of URLs which support understanding of how the
+	// competency might be met. This array may be empty,
+	// indicating that there are no supporting URLs
+	"supportingUrls": [
+		{
+			"label": String,
+			"url": String
+		}
+	],
+
 	// A longer description of the competency. This may be null
 	// if the competency has no description
 	"description": String,

--- a/test/schema/competencies.js
+++ b/test/schema/competencies.js
@@ -58,6 +58,14 @@ module.exports = {
 						minLength: 5
 					}
 				},
+				supportingUrls: {
+					title: 'Supporting URLs',
+					description: 'Any URLs which are useful in helping to understand a competency',
+					type: 'array',
+					items: {
+						$ref: '#/definitions/supportingUrl'
+					}
+				},
 				level: {
 					title: 'Level',
 					description: 'The level that this competency applies to',
@@ -94,9 +102,35 @@ module.exports = {
 				'summary',
 				'description',
 				'examples',
+				'supportingUrls',
 				'level',
 				'area',
 				'domain'
+			],
+			additionalProperties: false
+		},
+		supportingUrl: {
+			title: 'Supporting URL',
+			description: 'A URL which is useful in helping to understand a competency',
+			type: 'object',
+			properties: {
+				label: {
+					title: 'Label',
+					description: 'A label which identifies the link',
+					type: 'string',
+					minLength: 2
+				},
+				url: {
+					title: 'URL',
+					description: 'The URL which supports the competency',
+					type: 'string',
+					minLength: 5,
+					pattern: '^https?:\/\/'
+				}
+			},
+			required: [
+				'label',
+				'url'
 			],
 			additionalProperties: false
 		}


### PR DESCRIPTION
**Note to reviewer:** this is currently a draft because it builds on top of the
work in #289. Once that PR is merged I'll be able to rebase this branch and
open the PR properly.

For now, reviewing this PR as a whole would be duplicating effort. The
relevant commit is 7abe21b

---

In #276 we discussed the need for competencies to have supporting URLs -
sometimes more information would be useful to help understand the
competency, and URLs allow us to do this without bloating the summary or
examples.

I decided to make supporting URLs an array of objects. Using an object
rather than just the URL as a string allows us to display different link
text to help a user understand what they're clicking on.

I've also added an empty supporting URL array to all of the
competencies. This follows our decision with competency examples: it's
useful for consumers of the API to be able to trust that certain fields
are always going to be an array, reducing logic in their code.