### PR TITLE
Add supporting URLs to the website

### DIFF
--- a/site/_includes/competency-list.html
+++ b/site/_includes/competency-list.html
@@ -37,9 +37,12 @@
 							{% if competency.level == level.id and competency.area == area_lower_case %}
 								<tr id="{{competency.id}}">
 									{% assign example-count = competency.examples | size %}
+									{% assign supporting-url-count = competency.supportingUrls | size %}
 									<td>{{area}}</td>
 									<td>
-										{{competency.summary}}{% if example-count > 0 %}, e.g.{% endif %}
+										<p class="o-layout__unstyled-element competency-table__paragraph">
+											{{competency.summary}}{% if example-count > 0 %}, e.g.{% endif %}
+										</p>
 										{% if example-count > 0 %}
 											<ul class="o-layout__unstyled-element competency-table__examples">
 												{% for example in competency.examples %}
@@ -47,6 +50,17 @@
 												{% endfor %}
 											</ul>
 										{% endif %}
+										{% if supporting-url-count > 0 %}
+											<p class="o-layout__unstyled-element competency-table__paragraph">Supporting URLs:</p>
+											<ul class="o-layout__unstyled-element competency-table__supporting-urls">
+												{% for supportingUrl in competency.supportingUrls %}
+													<li>
+														<a href="{{supportingUrl.url}}">{{supportingUrl.label}}</a>
+													</li>
+												{% endfor %}
+											</ul>
+										{% endif %}
+
 									</td>
 									<!--
 									This additional column is hidden by default, but is visible when

--- a/site/css/main.scss
+++ b/site/css/main.scss
@@ -27,7 +27,14 @@
 	}
 }
 
-// Competency table styles (for print CSS)
+// Competency table styles (including for print CSS)
+.competency-table__paragraph {
+	margin: 0;
+
+	&:not(:first-child) {
+		margin-top: .5em;
+	}
+}
 .competency-table__evidence {
 	display: none;
 	@media print {
@@ -40,10 +47,13 @@
 		min-height: 5em;
 	}
 }
-.competency-table__examples {
+.competency-table__examples,
+.competency-table__supporting-urls {
 	margin-bottom: 0;
 	margin-top: .5em;
 	list-style: disc;
+}
+.competency-table__examples {
 	font-style: italic;
 }
 


### PR DESCRIPTION
This is slightly quick-and-dirty, but gets supporting URLs onto the
website. A separate PR should be opened for the spreadsheet, I
anticipate that work being more difficult.

It looks like this:
<img width="884" alt="Screenshot 2019-11-22 at 15 16 59" src="https://user-images.githubusercontent.com/138944/69437413-2dbfd680-0d3b-11ea-9286-73ed580f572a.png">
