### PR TITLE
Reword documentation to remove implications about promotion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Anybody working for the Financial Times is welcome to suggest changes via a GitH
 There are many different ways you can contribute and help make this resource better for everyone:
 
   - **Contribute to the Engineering Competencies**<br/>
-    The Engineering competencies are used to help identify when an engineer is ready for promotion. Every engineer in the CTO organisation of the Financial Times can help shape these competencies. While they are in alpha and beta we are especially interested in contributions.  [A guide for adding or editing competencies is here](docs/competencies.md).
+    The Engineering competencies are used to inform conversations about career progression between an engineer and their line manager. Every engineer in the CTO organisation of the Financial Times can help shape these competencies. While they are in alpha and beta we are especially interested in contributions.  [A guide for adding or editing competencies is here](docs/competencies.md).
 
   - **Contribute to the documentation and website**<br/>
     It's important that the documentation in this repo and the Engineering Progression website are clear and easy to understand. [Get started maintaining the documentation](docs/documentation.md)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Careers and progression for engineers in the CTO organisation.
 
-:info: This project is currently in **BETA**. You may use this to guide promotions decisions from September 2019.
+:info: This project is currently in **BETA**.
 
 ---
 
@@ -12,37 +12,35 @@ Careers and progression for engineers in the CTO organisation.
   - [Contributing](#contributing)
   - [Licence](#licence)
 
-
 ## Overview
 
 This repository is the single source of truth for the competencies and level definitions for Engineering roles in the CTO organisation at the FT.
 
 Keeping this framework in GitHub means we can use issues and pull requests to track and discuss changes to the competencies and role descriptions. Storing it in this way also allows us to version it and release any changes.
 
-This framework can be used in its raw form (YAML files), but it is also availble via JSON endpoint, which means other things can be built off it (eg a Google Sheet)
+This framework can be used in its raw form (YAML files), but it is also available via JSON endpoint, which means other things can be built off it (eg a Google Sheet)
 
 ## Engineering Competencies
 
-Engineering competencies are used to help identify when an engineer is ready for promotion. There are several ways that you can read through these competencies and track progress:
+Engineering competencies are used to inform conversations about career progression between an engineer and their line manager. There are several ways that you can read through these competencies and track progress:
 
   - [Track progress with your manager or report via Google Sheets](https://docs.google.com/spreadsheets/d/1V0LIbCQtJsi2iowfJnRTDr4Na4LhNAlJ_UHl9dDQs00/edit)
-  
+
   - [View all competencies on the website](https://engineering-progression.ft.com/competencies/)
-  
+
   - [Access competencies data via the JSON API](https://engineering-progression.ft.com/docs/api/)
 
   - [Read the engineering competencies as YAML in this repository](data/competencies.yml)
-
 
 ## Contributing
 
 Anybody working for the Financial Times is welcome to suggest changes via a GitHub issue or pull request. We maintain a [contributing guide](CONTRIBUTING.md) to help people who are interested. There are many different ways you can contribute and help make this resource better for everyone:
 
   - **Contribute to the Engineering Competencies**<br/>
-The Engineering competencies are used to help identify when an engineer is ready for promotion. Every engineer in the CTO organisation of the Financial Times can help shape these competencies. While they are in alpha and beta we are especially interested in contributions.  [A guide for adding or editing competencies is here](docs/competencies.md).
+    Every engineer in the CTO organisation of the Financial Times can help shape these competencies. While they are in alpha and beta we are especially interested in contributions.  [A guide for adding or editing competencies is here](docs/competencies.md).
 
   - **Contribute to the documentation and website**<br/>
-    It's important that the documentation in this repo and the Engineering Progression website are clear and easy to understand. [Get started maintaining the documentation](docs/documentation.md)
+    It's important that the documentation in this repo and the Engineering Progression website is clear and easy to understand. [Get started maintaining the documentation](docs/documentation.md)
 
   - **Build your own integration**<br/>
     The competencies data is available through a JSON API, which means that engineers at the Financial Times can build their own integrations on top of it. [Get started writing your own integrations](docs/integrations.md)

--- a/docs/competencies.md
+++ b/docs/competencies.md
@@ -1,7 +1,7 @@
 
 # Contributing: Engineering Competencies
 
-The Engineering competencies are used to help identify when an engineer is ready for promotion. Every engineer in the CTO organisation of the Financial Times can help shape these competencies. While they are in alpha and beta we are especially interested in contributions.
+The Engineering competencies are used to inform conversations about career progression between an engineer and their line manager. Every engineer in the CTO organisation of the Financial Times can help shape these competencies. While they are in alpha and beta we are especially interested in contributions.
 
   - [Language Guidelines](#language-guidelines)
   - [Editing on GitHub](#editing-on-github)

--- a/docs/language.md
+++ b/docs/language.md
@@ -85,7 +85,7 @@ These guidelines apply to writing engineering competencies, and expand on the ge
 
 ### Consider whether the competency is demonstrable
 
-When an engineer is ready for promotion, they are expected to provide evidence of the competencies that apply to their domain. It is important that each competency is demonstrably done:
+When an engineer discusses their career progression with their manager, they should be able to agree whether a competency is fulfilled. It is important that each competency is demonstrable:
 
   - **bad**: "Can write tests"
   - **good**: "Writes tests"

--- a/docs/repository.md
+++ b/docs/repository.md
@@ -46,11 +46,9 @@ There are some things that need to happen immediately after a release, which unf
 
 A major version bump must happen when a change to the engineering competencies requires something **new** of an engineer to meet the level above their current one.
 
-For example: if we decide that we now expect Junior Engineers to be able to fold a perfect Origami crane before they can be promoted to a Mid-level Engineer, then this is a major version bump to the competencies.
+For example: if we decide that we now expect Mid-level Engineers to be able to fold a perfect Origami crane, then this is a major version bump to the competencies.
 
-A major version bump must not be made without consulting the promotions board (process TBC). It's important that an intention to increment the major version is communicated to all engineers that it affects.
-
-Once a major version has been released, it may not be implemented by the promotions board until several promotions rounds _after_ the release date (process TBC).
+It's important that an intention to increment the major version is communicated to everybody it affects, including engineers, line managers and people who may consider the competencies when making promotion decisions. A major version change should also be coordinated around the timing of promotion rounds.
 
 ### Minor Versions
 

--- a/script/deploy-google-sheets.js
+++ b/script/deploy-google-sheets.js
@@ -94,7 +94,7 @@ async function deployGoogleSheets({competencies, competenciesVersion, jsonAuthDa
 		// warnings about editing the sheet manually, and links to useful resources
 		batchedUpdates.push(createBatchCellUpdate(overviewSheetId, [
 			['Engineering Progression'],
-			['This is an example spreadsheet for tracking engineering progression. This sheet is generated automatically, any edits you make here will be overwritten (including comments).\n\nThis spreadsheet contains sheets for the different levels of engineer, you can use these to track a person\'s progress towards their next promotion. Please make a copy of this spreadsheet to do this.'],
+			['This is an example spreadsheet for tracking engineering progression. This sheet is generated automatically. Any edits you make here will be overwritten (including comments).\n\nThis spreadsheet contains sheets for the different levels of engineer. You can use these to inform conversations about career progression with engineers. Please make a copy of this spreadsheet to do this.'],
 			[''],
 			['=HYPERLINK("https://engineering-progression.ft.com/competencies/how-to-use/", "Before tracking your progress, it\'s best to read how to use the competencies.")'],
 			[''],

--- a/site/pages/competencies/how-to-use.md
+++ b/site/pages/competencies/how-to-use.md
@@ -5,14 +5,15 @@ permalink: /competencies/how-to-use/
 layout: o-layout-docs
 ---
 
-
 # {{page.title}}
 
-Engineering competencies are used to help identify when an engineer is ready for promotion. Competencies are _one_ part of the promotions process for engineers at the FT, meeting most or all of them indicates that an engineer may be ready for promotion. We divide competencies into levels for different seniorities.
+Engineering competencies are used to inform conversations about career progression between an engineer and their line manager. They define what an engineer is expected to be doing at a particular level. They are not a checklist, but a way to indicate what areas they may need to improve in. We also expect engineers to be meeting competencies from the levels _before_ their current one.
+
+We divide competencies into levels for different seniorities.
 
 ## Levels
 
-Each level represents the work needed to be promoted from one role into another, so the name of each level contains two different job titles:
+Each level represents the expectations and responsibilities that change from one level into another, so the name of each level contains two different job titles:
 
 <ul>
 {% for level in site.data.levels %}
@@ -20,19 +21,11 @@ Each level represents the work needed to be promoted from one role into another,
 {% endfor %}
 </ul>
 
-So, for example, a Junior Engineer should be working towards the competencies at the "Junior to Mid" level.
-
-When putting forward an engineer for a promotion, you are expected to provide evidence that you're meeting the competencies for the new level. We also expect engineers to be meeting competencies from the levels _before_ their current one, but we do not require evidence of this in a promotions round.
+So, for example, a Junior Engineer should be considering the competencies at the "Junior to Mid" level.
 
 ## Competencies
 
-Each competency has a summary which is designed to prompt a yes/no response. For each competency, an engineer should feel able to answer either _"yes, I'm meeting this competency"_, or _"no, I'm not meeting this competency yet"_.
-
-As part of a promotions process, an engineer must specify which competencies they are meeting for a level. We don't expect that _every_ engineer will meet _all_ of the competencies, but the promotions board will consider all of the competencies as part of the decision-making process. Domain-specific competencies that don't apply to an engineer's role or specialism will not be considered as part of a promotions case.
-
-Engineers are expected to provide evidence that they are meeting a competency when it comes to writing a promotions case. We expect a sentence or two, and an engineer's line manager should be ready to provide further detail if necessary. It's fine to use the same evidence for multiple competencies. Evidence must also be provided for competencies that are not being met to explain why they have not or cannot be met.
-
-An example of how you might provide evidence for met and unmet competencies:
+Each competency has a summary which is designed to prompt a yes/no response. For each competency, an engineer should feel able to answer either _"yes, I'm meeting this competency"_, or _"no, I'm not meeting this competency, yet"_. An engineer and their line manager should keep a record of evidence for meeting each competency, for example:
 
 <table class="o-table o-layout__main__single-span" data-o-component="o-table">
 	<tr>

--- a/site/pages/competencies/index.html
+++ b/site/pages/competencies/index.html
@@ -1,6 +1,6 @@
 ---
 title: Engineering Competencies
-description: Engineering competencies are used to help identify when an engineer is ready for promotion.
+description: Engineering competencies are used to inform conversations about career progression between an engineer and their line manager.
 permalink: /competencies/
 layout: o-layout-landing
 ---
@@ -10,7 +10,7 @@ layout: o-layout-landing
 
 	<h1>{{page.title}}</h1>
 	<p>
-		Engineering competencies are used to help identify when an engineer is ready for promotion.
+		{{page.description}}
 		This section of the site outlines the competencies for each level of engineer. Before reviewing competencies for your level,
 		<a href="/competencies/how-to-use/">read how to use them here</a>.
 	</p>

--- a/site/pages/competencies/junior-to-mid.html
+++ b/site/pages/competencies/junior-to-mid.html
@@ -1,6 +1,6 @@
 ---
 title: Junior to Mid Level Engineering Competencies
-description: Engineering competencies for engineers who are aiming to be promoted from Junior Engineer to Engineer.
+description: Engineering competencies for engineers moving from Junior Engineer to Engineer.
 permalink: /competencies/junior-to-mid/
 layout: o-layout-docs
 ---

--- a/site/pages/competencies/mid-to-senior1.html
+++ b/site/pages/competencies/mid-to-senior1.html
@@ -1,6 +1,6 @@
 ---
 title: Mid to Senior 1 Level Engineering Competencies
-description: Engineering competencies for engineers who are aiming to be promoted from Engineer to Senior 1 Engineer.
+description: Engineering competencies for engineers moving from Engineer to Senior 1 Engineer.
 permalink: /competencies/mid-to-senior1/
 layout: o-layout-docs
 ---

--- a/site/pages/competencies/senior1-to-senior2.html
+++ b/site/pages/competencies/senior1-to-senior2.html
@@ -1,6 +1,6 @@
 ---
 title: Senior 1 to Senior 2 Level Engineering Competencies
-description: Engineering competencies for engineers who are aiming to be promoted from Senior 1 Engineer to Senior 2 Engineer.
+description: Engineering competencies for engineers moving from Senior 1 Engineer to Senior 2 Engineer.
 permalink: /competencies/senior1-to-senior2/
 layout: o-layout-docs
 ---

--- a/site/pages/competencies/senior2-to-principal.html
+++ b/site/pages/competencies/senior2-to-principal.html
@@ -1,6 +1,6 @@
 ---
 title: Senior 2 to Principal Level Engineering Competencies
-description: Engineering competencies for engineers who are aiming to be promoted from Senior 2 Engineer to Principal Engineer.
+description: Engineering competencies for engineers moving from Senior 2 Engineer to Principal Engineer.
 permalink: /competencies/senior2-to-principal/
 layout: o-layout-docs
 ---

--- a/site/pages/faq.md
+++ b/site/pages/faq.md
@@ -9,7 +9,7 @@ layout: o-layout-docs
 
 ## Is there an individual contributor route?
 
-There is no separate individual contributor route to promotion, but the aim
+There is no separate individual contributor route for progression, but the aim
 is to have a single set of competencies that are flexible enough to allow for
 a variety of ways that an engineer can demonstrate seniority.
 
@@ -28,9 +28,7 @@ that you are having a positive impact on others' work in other ways.
 ## There are no competencies for Principal Engineer. Why is this?
 
 The Product & Technology Executive/Technology Leadership Group made a decision
-in 2018: Principal roles and beyond must have a position open and advertised.
-The promotions board therefore plays no role in deciding who becomes a
-Principal Engineer, so there are no competencies defined at this stage. The
+in 2018: Principal roles and beyond must have a position open and advertised. The
 recruiting manager for each Principal Engineer role defines what the criteria
 for that role will be.
 
@@ -46,7 +44,7 @@ existing Senior 2 Engineers.
 
 ## Do I need to meet competencies from earlier levels?
 
-Yes. For example we expect our Senior 2 Engineers to still be exhibiting the competencies from the "Mid to Senior 1" level as well as the "Senior 1 to Senior 2" level. Though you are not tested for earlier levels when going for a promotion.
+Yes. For example we expect our Senior 2 Engineers to still be exhibiting the competencies from the "Mid to Senior 1" level as well as the "Senior 1 to Senior 2" level.
 
 Assuming that competencies from earlier levels are met means that we do not need to duplicate competencies across different levels.
 
@@ -73,4 +71,4 @@ Engineers at the FT that do not report in the the CTO may also find this framewo
 
 ## Are competencies weighted / are some competencies more important than others?
 
-No, competencies are not weighted. Meeting one competency over another is not an indication that one engineer is closer to promotion than another engineer.
+No, competencies are not weighted. No competency is more important than any other for an engineer's progression.

--- a/site/pages/home.html
+++ b/site/pages/home.html
@@ -33,8 +33,7 @@ layout: o-layout-landing
 		<div class="o-layout-item">
 			<h2>Competencies</h2>
 			<p>
-				Engineering competencies are used to help identify when an engineer is ready for
-				promotion:
+				Engineering competencies are used to inform conversations about career progression between an engineer and their line manager:
 			</p>
 			<ul>
 				<li><a href="/competencies/">View all competencies</a></li>


### PR DESCRIPTION
As discussed in the Working Group, the current wording doesn't correctly convey the intention of the progression framework, and can wrongly imply it's a checklist of the things an engineer needs to do to get promoted, rather than a map of responsibilities and expectations at each level (which may be one of the things considered when applying for promotion, but it's not the whole picture)