### PR TITLE
move How To Use link to top level

### DIFF
--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -21,6 +21,11 @@
 				</a>
 			</li>
 			<li>
+				<a href="/competencies/how-to-use/" {% if page.url == '/competencies/how-to-use/' %}aria-current="true"{% endif %}>
+					How to use
+				</a>
+			</li>
+			<li>
 				<a href="/docs/api/" {% if page.url == '/docs/api/' %}aria-current="true"{% endif %}>
 					API
 				</a>
@@ -44,11 +49,6 @@
 					</li>
 				</ol>
 				<ul class="o-header-services__secondary-nav-list o-header-services__secondary-nav-list--children" aria-label="Child sections">
-					<li>
-						<a href="/competencies/how-to-use/" {% if page.url == '/competencies/how-to-use/' %}aria-current="true"{% endif %}>
-							How to use
-						</a>
-					</li>
 					{% for level in site.data.levels %}
 						<li>
 							{% capture level_url %}/competencies/{{level.id}}/{% endcapture %}


### PR DESCRIPTION
action from the Working Group 10/3 meeting. we believe making this link more prominent will mean more people are aware of this page

- [ ] should the page URL also be moved from `/competencies/how-to-use` to `/how-to-use`?