### PR TITLE
Amending Junior->Mid to deliver high quality code solutions

### DIFF
--- a/data/competencies.yml
+++ b/data/competencies.yml
@@ -22,11 +22,12 @@
   domain: null
 
 - id: 574c234d-b52e-4765-b160-bac958e2d207
-  summary: Uses code to make something
+  summary: Delivers high quality code and solutions
   examples:
     - Takes a feature from their team backlog and writes the code for that feature
     - Automates a regular task using Python
     - Writes a CloudFormation template
+    - Gets involved in refactoring of code to improve clarity, readability and maintainability. 
   supportingUrls: []
   description: null
   level: junior-to-mid


### PR DESCRIPTION
WHY

An issue was raised by a colleague that explained they would like to see 'Deliver High Quality Code and Solutions also in the Junior to Mid framework, as all engineers value this when writing code and delivering solutions.

WHAT

Amended summary of Junior-Mid from 'Uses code to make something' to 'Delivers high quality code and solutions'. I believe that the first three examples that were there should be  kept, as these are important. I have added 'Get Involved in Refactoring' as Juniors perhaps need more supervision on the refactoring side over a Mid.