### PR TITLE
Add clarity around completion of competencies and promotions

### DIFF
--- a/site/pages/competencies/how-to-use.md
+++ b/site/pages/competencies/how-to-use.md
@@ -45,6 +45,8 @@ Each competency has a summary which is designed to prompt a yes/no response. For
 	</tr>
 </table>
 
+In the second example the engineer is unable to meet the competency "Leads hiring process for new Engineers" because that opportunity hasn't come up in their current role. This is fine: it's not a requirement for the engineer to be meeting all of the competencies, however this may be an indication to that engineer's line manager that opportunities need to be found or created.
+
 A copy of the <a href="https://docs.google.com/spreadsheets/d/1V0LIbCQtJsi2iowfJnRTDr4Na4LhNAlJ_UHl9dDQs00/edit" class="o-typography-link--external">Engineering Progression Tracker (Google Sheet)</a> is useful for keeping track of progress.
 
 ### Domain-specific competencies

--- a/site/pages/competencies/how-to-use.md
+++ b/site/pages/competencies/how-to-use.md
@@ -7,7 +7,7 @@ layout: o-layout-docs
 
 # {{page.title}}
 
-Engineering competencies are used to inform conversations about career progression between an engineer and their line manager. They define what an engineer is expected to be doing at a particular level. They are not a checklist, but a way to indicate what areas they may need to improve in. We also expect engineers to be meeting competencies from the levels _before_ their current one.
+Engineering competencies are used to inform conversations about career progression between an engineer and their line manager. They define what an engineer is expected to be doing at a particular level. They are not a checklist, but a way to indicate what areas they may need to improve in.
 
 We divide competencies into levels for different seniorities.
 
@@ -21,7 +21,7 @@ Each level represents the expectations and responsibilities that change from one
 {% endfor %}
 </ul>
 
-So, for example, a Junior Engineer should be considering the competencies at the "Junior to Mid" level.
+So, for example, a Junior Engineer should be considering the competencies at the "Junior to Mid" level. We also expect engineers to be considering whether they're meeting competencies from the levels _before_ their current one, though we don't ask for evidence of this.
 
 ## Competencies
 

--- a/site/pages/faq.md
+++ b/site/pages/faq.md
@@ -50,7 +50,7 @@ existing Senior 2 Engineers.
 
 ## Do I need to meet competencies from earlier levels?
 
-Yes. For example we expect our Senior 2 Engineers to still be exhibiting the competencies from the "Mid to Senior 1" level as well as the "Senior 1 to Senior 2" level.
+You should be considering them, however we do not ask for evidence on competencies from earlier levels. For example we expect our Senior 2 Engineers to still be exhibiting the competencies from the "Mid to Senior 1" level as well as the "Senior 1 to Senior 2" level but they do not need to record them in their tracker.
 
 Assuming that competencies from earlier levels are met means that we do not need to duplicate competencies across different levels.
 

--- a/site/pages/faq.md
+++ b/site/pages/faq.md
@@ -56,6 +56,14 @@ Assuming that competencies from earlier levels are met means that we do not need
 
 This is covered in the ["how to use the competencies" guide](/competencies/how-to-use/).
 
+## Do I need to meet all of the competencies?
+
+No. Competencies define what an engineer is expected to be doing at a particular level, and an engineer should be striving to meet as many of them as possible. However sometimes it may not be possible for an engineer to meet certain competencies in their current role.
+
+For example, the competency "Regularly collaborates with team members from other disciplines to deliver features" would be difficult to meet for a person who works on a team which consists of only engineers.
+
+In cases where an engineer's current role prevents them from meeting a competency, the engineer's line manager should try to find opportunities for the engineer to do so.
+
 ## Do I need to provide evidence for all of the examples in a competency?
 
 No. Examples are illustrative, and it's possible to meet a competency in a different way. This is covered in the ["how to use the competencies" guide](/competencies/how-to-use/).

--- a/site/pages/faq.md
+++ b/site/pages/faq.md
@@ -64,6 +64,14 @@ For example, the competency "Regularly collaborates with team members from other
 
 In cases where an engineer's current role prevents them from meeting a competency, the engineer's line manager should try to find opportunities for the engineer to do so.
 
+## How do competencies relate to promotions?
+
+Promotion forms ask for evidence of an engineer's readiness for promotion. The competencies are a framework for use by an engineer and their line manager to inform discussions on areas for improvement, the evidence that they compile is likely to be useful in a promotions case.
+
+This provided evidence is not the only thing considered in a promotion case, for example feedback from stakeholders and peers is factored in.
+
+The progression framework is not a check-list: providing evidence for all of the competencies does not guarantee promotion. Similarly if you're unable to provide evidence for some of the competencies then this does not rule out a successful promotion case (see [_Do I need to meet all of the competencies?_](#do-i-need-to-meet-all-of-the-competencies)).
+
 ## Do I need to provide evidence for all of the examples in a competency?
 
 No. Examples are illustrative, and it's possible to meet a competency in a different way. This is covered in the ["how to use the competencies" guide](/competencies/how-to-use/).


### PR DESCRIPTION
This adds some clarity across the Engineering Progression website on:
  * Whether an engineer needs to be meeting all of the competencies
  * How the competencies relate to promotions

This is based on mine and the Working Group's understanding of the progression framework. Some of this I assumed was documented already, but I was unable to find anything.

## On meeting all the competencies

We (in the working group) have understood it like this for a long time. The examples on the [How to use the Competencies page](https://engineering-progression.ft.com/competencies/how-to-use/#competencies) do demonstrate the evidence to provide if you can't meet a competency:

> The team has not had to hire new engineers in the last year, and so this competency cannot be met

But we were not explicit about this. A new entry on the how to use page and a new frequently asked question have been added to remedy this.

## On promotions

So far we've made efforts to avoid conflating promotions with competencies. The site and competencies themselves make no reference to promotions, and this was deliberate. One of our rounds of feedback showed us that people interpreted the competencies as a check-list – "tick these boxes, get a promotion". This is incorrect, and so a year ago [we adjusted language](https://github.com/Financial-Times/engineering-progression/pull/288) (and removed the literal checkboxes from the spreadsheet 🤦 that one was definitely our bad).

I think we went too far by removing references to promotion entirely, and our changes haven't remedied misconceptions about how competencies relate to promotions. This PR adds a new frequently asked question which clarifies how the competencies relate to promotions.

You'll notice that the language is a _little_ vague and doesn't commit to too much. That's because we're not the promotions board, and it's not the job of this website to document how the promotions process works. I hope it still adds clarity.

## On why this is one PR instead of two

I think these two points are really tightly linked – in order to talk about competencies being used in promotions I also needed to make sure that we were clear that it's OK to _not_ meet some of them. If one of these items is fine and the other needs more work, I'm happy to break this up to get part of it merged in.