### PR TITLE
RE-2264 Automatically creating CODEOWNERS file [Skip CI]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Guessed from System and Package relationships in Biz Ops
+* @Financial-Times/engineering-progression-working-group


### PR DESCRIPTION
Created by https://github.com/Financial-Times/codeowners-creation