### PR TITLE
loosen ruby version constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-ruby '~> 2.4.0'
+ruby '~> 2.4'
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
allows the constraint to match any 2.x version greater than 2.4, not just 2.4.x versions