### PR TITLE
Revert GSD copy changes to the job family page and fix capitalisation

### DIFF
--- a/site/pages/job-families.md
+++ b/site/pages/job-families.md
@@ -17,13 +17,13 @@ Engineers at early stages are Individual Contributors (hands-on), and later have
 
 ## Global Service Desk
 
-In the Global Service Desk - interviews are required to progress from individual contributor roles, into people manager / roles, however - progression from Analyst to Technician can be completed through promotion board or by interview.
+Progression within Individual Contributor roles can be achieved through the promotion process. Those choosing to pursue a People Manager role must demonstrate the competences and experience necessary, and complete a successful interview when a specific business need/role is available.
 
 ![A diagram showing the different progression paths in Global Service Desk](/media/service-desk-roles.png)
 
 ## Operations
 
-Progression within Individual contributor roles can be achieved through the promotion process. Those choosing to pursue a People Manager role must demonstrate the competences and experience necessary, and complete a successful interview when a specific business need/role is available.
+Progression within Individual Contributor roles can be achieved through the promotion process. Those choosing to pursue a People Manager role must demonstrate the competences and experience necessary, and complete a successful interview when a specific business need/role is available.
 
 ![A diagram showing the different progression paths in Operations](/media/operations-roles.png)
 


### PR DESCRIPTION
Chris Hall requested this copy be reverted: it turns out he only wanted an update to the related image. I’ve also taken the liberty of capitalising “Individual Contributor” for consistency.